### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ADD https://github.com/djmaze/armhf-forego/releases/download/v0.16.1/forego /usr
 RUN chmod u+x /usr/local/bin/forego
 
 ENV DOCKER_GEN_VERSION 0.7.3
+ENV NGINX_VERSION 1.10.2
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-armhf-$DOCKER_GEN_VERSION.tar.gz \


### PR DESCRIPTION
Add NGINX_VERSION environment variable. This is required if you want to use the letsencrypt-nginx-proxy-companion next to this Docker.

See https://github.com/budrom/docker-rpi-letsencrypt-nginx-proxy-companion/blob/master/app/entrypoint.sh#L31